### PR TITLE
Fix path parsing with valid \n

### DIFF
--- a/lib/parser/util.js
+++ b/lib/parser/util.js
@@ -2,13 +2,9 @@
 var path = require('path');
 function parseFilepath(s) {
     if (s) {
-        // remove newlines
-        s = s.replace('\\n', '');
-        // sanitize with path.parse first
+        s = s.replace('\n', '');
         var parsed = path.parse(s);
-        // join it back and replace Windows' stupid backslash with slash
         var joined = path.join(parsed.dir, parsed.base).split(path.sep).join('/');
-        // fuck Windows Bidi control character
         if (joined.charCodeAt(0) === 8234)
             joined = joined.substr(1);
         return joined.trim();
@@ -21,10 +17,9 @@ exports.parseFilepath = parseFilepath;
 function parseInputContent(data) {
     var expr = data.toString()
         .replace(/\\/g, '\\\\')
-        .replace(/\\/g, '\\\\') // \           => \\
-        .replace(/\"/g, '\"') // "           => \"
-        .replace(/\n/g, '\\n'); // newline     => \\n
-    // trim spaces
+        .replace(/\\/g, '\\\\')
+        .replace(/\"/g, '\"')
+        .replace(/\n/g, '\\n');
     if (atom.config.get('agda-mode.trimSpaces'))
         return expr.trim();
     else

--- a/src/parser/util.ts
+++ b/src/parser/util.ts
@@ -5,7 +5,7 @@ declare var atom: any;
 function parseFilepath(s: string): string {
     if (s) {
         // remove newlines
-        s = s.replace('\\n', '');
+        s = s.replace('\n', '');
         // sanitize with path.parse first
         const parsed = path.parse(s);
         // join it back and replace Windows' stupid backslash with slash


### PR DESCRIPTION
Paths such as "...\IAL\nat.agda" would be parsed as ".../IALat.agda" incorrectly and fail to load, on Windows.
This fixes this issue.