### PR TITLE
Fix \\n responses in windows

### DIFF
--- a/lib/parser/agda.js
+++ b/lib/parser/agda.js
@@ -201,6 +201,8 @@ function preprocess(chunk) {
         chunk = chunk.substring(12);
         chunk = "(agda2-parse-error" + chunk + ")";
     }
+    // Replace window's \\ in paths with /, so that \n doesn't get treated as newline.
+    chunk = chunk.replace(/\\\\/g, "/");
     return chunk;
 }
 //# sourceMappingURL=agda.js.map

--- a/src/parser/agda.ts
+++ b/src/parser/agda.ts
@@ -204,7 +204,8 @@ function preprocess(chunk: string): string {
         chunk = chunk.substring(12);
         chunk = `(agda2-parse-error${chunk})`;
     }
-
+    // Replace window's \\ in paths with /, so that \n doesn't get treated as newline.
+    chunk = chunk.replace(/\\\\/g, "/");
     return chunk;
 }
 


### PR DESCRIPTION
For example, for the response `(agda2-info-action "*Scope Info*" "_+_ is in scope as\n  * a defined name nat._+_ brought into scope by\n    - the opening of nat at\n    - its definition at C:\\Users\\Ilan\\Programming\\IAL\\nat.agda:36,1-4" nil)`, the `\\nat` at the end would be treated as `\~newline~at`.

We should probably properly unescape everything in one location