### PR TITLE
Fix Unicode input example

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ See [Agda:Issue 850](https://code.google.com/p/agda/issues/detail?id=850) for mo
 
 ### Unicode input method (only invokable under `.agda` or `.lagda`)
 
-The key mapping of symbols are the same as in Emacs. For example: `\bn` for `ℕ`, `\all` for `∀`, `\r` or `\to` for `→`, etc.
+The key mapping of symbols are the same as in Emacs. For example: `\bN` for `ℕ`, `\all` for `∀`, `\r` or `\to` for `→`, etc.
 
 | Keymap                                     | Command                            |
 |-------------------------------------------:|:-----------------------------------|


### PR DESCRIPTION
Thank you for this amazing Atom package.

This PR fixes a tiny mistake in the README: `\bn` produces a lowercase double-struck n, but the example shows an uppercase one.

Suggested fix: change input sequence to `\bN`.