### PR TITLE
added Cmd_autoOne for Agda 2.5.4

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -131,9 +131,13 @@ export const refine = (goal: Goal) => buildRequest('NonInteractive', conn =>
     (`Cmd_refine_or_intro False ${goal.index} ${buildRange(conn, goal)} \"${goal.getContent()}\"`)
 );
 
-export const auto = (goal: Goal) => buildRequest('NonInteractive', conn =>
-    (`Cmd_auto ${goal.index} ${buildRange(conn, goal)} \"${goal.getContent()}\"`)
-);
+export const auto = (goal: Goal) => buildRequest('NonInteractive', conn => {
+    if (semver.gte(conn.version.sem, '2.5.4')) {
+        return `Cmd_autoOne ${goal.index} ${buildRange(conn, goal)} \"${goal.getContent()}\"`;
+    } else {
+        return `Cmd_auto ${goal.index} ${buildRange(conn, goal)} \"${goal.getContent()}\"`;
+    }
+});
 
 export const makeCase = (goal: Goal) => buildRequest('NonInteractive', conn =>
     (`Cmd_make_case ${goal.index} ${buildRange(conn, goal)} \"${goal.getContent()}\"`)


### PR DESCRIPTION
Hi,

in the current 2.6.0 pre-release https://hackage.haskell.org/package/Agda-2.5.4.2.20190310/candidate/Agda-2.5.4.2.20190310.tar.gz
the `Cmd_auto` command was changed in [Agda's PR3282](https://github.com/agda/agda/pull/3282).

This might only affect ≥ v2.5.4.2 but my Agda just reports "2.5.4" for `conn.version.sem` with `agda --version` on 2.6.0-b946192.