### PR TITLE
windows path support for agda 2.5

### DIFF
--- a/src/Command.re
+++ b/src/Command.re
@@ -183,6 +183,12 @@ module Remote = {
   /* serializes Buffed Command into strings that can be sent to Agda */
   let serialize = self => {
     let {filepath, command, connection} = self;
+    let onWindows = N.OS.type_() == "Windows_NT";
+    let filepath = if (onWindows) {
+      Js.String.replaceByRe([%re "/\\\\/g"], "/", filepath);
+    } else {
+      filepath;
+    };
     let libraryPath: string = {
       let path = Atom.Environment.Config.get("agda-mode.libraryPath");
       path |> Js.Array.unshift(".") |> ignore;


### PR DESCRIPTION
fix https://github.com/banacorn/agda-mode/issues/98
not sure this is the right place for the path fix, and should probably be tested against other versions of agda?